### PR TITLE
Add support for new GlyphRange format introduced in v3.6

### DIFF
--- a/src/rmscene/scene_items.py
+++ b/src/rmscene/scene_items.py
@@ -200,7 +200,7 @@ class GlyphRange(SceneItem):
 
     `rectangles` represent the locations of the highlight.
     """
-    start: Optional[int]
+    start: tp.Optional[int]
     length: int
     text: str
     color: PenColor

--- a/src/rmscene/scene_items.py
+++ b/src/rmscene/scene_items.py
@@ -200,7 +200,7 @@ class GlyphRange(SceneItem):
 
     `rectangles` represent the locations of the highlight.
     """
-    start: int
+    start: Optional[int]
     length: int
     text: str
     color: PenColor

--- a/src/rmscene/scene_items.py
+++ b/src/rmscene/scene_items.py
@@ -188,6 +188,18 @@ class Rectangle:
 
 @dataclass
 class GlyphRange(SceneItem):
+    """Highlighted text
+
+    `start` is only available in SceneGlyphItemBlock version=0, prior to ReMarkable v3.6
+
+    `length` is the length of the text
+
+    `text` is the highlighted text itself
+
+    `color` represents the highlight color
+
+    `rectangles` represent the locations of the highlight.
+    """
     start: int
     length: int
     text: str

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -454,6 +454,7 @@ def glyph_range_from_stream(stream: TaggedBlockReader) -> si.GlyphRange:
 
     return si.GlyphRange(start, length, text, color, rectangles)
 
+
 def glyph_range_to_stream(stream: TaggedBlockWriter, item: si.GlyphRange):
     stream.write_int(2, item.start)
     stream.write_int(3, item.length)

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -441,7 +441,7 @@ def glyph_range_from_stream(stream: TaggedBlockReader) -> si.GlyphRange:
             color = si.PenColor(color_id)
             text = stream.read_string(5)
             length = len(text)
-            start = -1
+            start = None
         case other:
             _logger.warning("Unsupported version %d for GlyphRange", version)
 

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -16,7 +16,7 @@ import typing as tp
 
 from packaging.version import Version
 
-from .tagged_block_common import CrdtId, LwwValue
+from .tagged_block_common import CrdtId, LwwValue, UnexpectedBlockError
 from .tagged_block_reader import TaggedBlockReader
 from .tagged_block_writer import TaggedBlockWriter
 from .crdt_sequence import CrdtSequence, CrdtSequenceItem


### PR DESCRIPTION
Updates `glyph_range_from_stream` to handle glyphrange version=1 introduced in ReMarkable beta v3.6

See: https://github.com/ricklupton/rmscene/issues/14