### PR TITLE
Add checkbox support to ParagraphStyle in scene_items

### DIFF
--- a/src/rmscene/scene_items.py
+++ b/src/rmscene/scene_items.py
@@ -144,6 +144,8 @@ class ParagraphStyle(enum.IntEnum):
     BOLD = 3
     BULLET = 4
     BULLET2 = 5
+    CB_EMPTY = 6
+    CB_CHECKED = 7
 
 
 END_MARKER = CrdtId(0, 0)


### PR DESCRIPTION
This adds support for 2 new paragraph styles:
- `CB_EMPTY`: Empty checkbox
- `CB_CHECKED`: Checked checkbox