### PR TITLE
Add ParagraphStyle for checked checkbox

### DIFF
--- a/src/rmscene/scene_items.py
+++ b/src/rmscene/scene_items.py
@@ -146,6 +146,7 @@ class ParagraphStyle(enum.IntEnum):
     BULLET = 4
     BULLET2 = 5
     CHECKBOX = 6
+    CHECKBOX_CHECKED = 7
 
 
 END_MARKER = CrdtId(0, 0)


### PR DESCRIPTION
Currently checkbox has a ParagraphStyle (6) but checked checkbox uses a diffrent style (7) which is not implemented.

This PR simply adds `ParagraphStyle.CHECKBOX_CHECKED` (set to 7) to allow parsing of checked checkboxes.

If needed i can provide sample .rm files with checkboxes for testing.
