### PR TITLE
Ignore unknown IDs in sorting CrdtSequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ To convert rm files to other formats, you can use [rmc](https://github.com/rickl
 
 ### Unreleased
 
+Fixes:
+- Fix AssertionError when some ids are missing in a `CrdtSequence` ([#36](https://github.com/ricklupton/rmscene/pull/36))
+
 ### v0.6.0
 
 New features:

--- a/src/rmscene/crdt_sequence.py
+++ b/src/rmscene/crdt_sequence.py
@@ -2,12 +2,15 @@
 
 """
 
+import logging
 import typing as tp
 from typing import Iterable
 from collections import defaultdict
 from dataclasses import dataclass
 
 from .tagged_block_common import CrdtId
+
+_logger = logging.getLogger(__name__)
 
 
 # If the type constraint is for a CrdtSequenceItem[Superclass], then a
@@ -108,7 +111,9 @@ def toposort_items(items: Iterable[CrdtSequenceItem]) -> Iterable[CrdtId]:
 
     def _side_id(item, side):
         side_id = getattr(item, f"{side}_id")
-        if side_id == END_MARKER:
+        if side_id == END_MARKER or side_id not in item_dict:
+            if side_id != END_MARKER:
+                _logger.debug("Ignoring unknown %s_id %s of %s", side, side_id, item)
             return "__start" if side == "left" else "__end"
         else:
             return side_id

--- a/tests/test_crdt_sequence.py
+++ b/tests/test_crdt_sequence.py
@@ -71,6 +71,17 @@ def test_unknown_id():
     assert result1 == [cid(28), cid(31), cid(33), cid(15)]
 
 
+def test_unknown_id_at_right():
+    items = [
+        make_item(14, 0, 0, 0, "A"),
+        make_item(19, 14, 15, 0, "V"),
+        # item 15 is not defined -- this shouldn't happen, as there should be a
+        # tombstone, but don't want to raise errors in this case
+    ]
+    result = list(CrdtSequence(items))
+    assert result == [cid(14), cid(19)]
+
+
 def test_iterates_in_order():
     # Order should be "AB"
     items = [


### PR DESCRIPTION
Unknown IDs shouldn't happen anyway, but they have happened where the part of the file where they were defined was not being parsed properly. With this change the behaviour is more robust.

Fixes AssertionError part of #32 

Thanks @Seb-sti1 for the reproducer