### PR TITLE
Fix #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To convert rm files to other formats, you can use [rmc](https://github.com/rickl
 
 Fixes:
 - Fix AssertionError when some ids are missing in a `CrdtSequence` ([#36](https://github.com/ricklupton/rmscene/pull/36))
+- Fix ValueError when the node_id is missing in a `SceneGroupItemBlock` ([#16](https://github.com/ricklupton/rmscene/issues/16)) 
 
 ### v0.6.0
 

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -868,6 +868,8 @@ def build_tree(tree: SceneTree, blocks: Iterable[Block]):
         elif isinstance(b, SceneGroupItemBlock):
             # Add this entry to children of parent_id
             node_id = b.item.value
+            if node_id is None:
+                continue
             if node_id not in tree:
                 raise ValueError(
                     "Node does not exist for SceneGroupItemBlock: %s" % node_id


### PR DESCRIPTION
This should fix #16 

As Rick Lupton guessed in the issue `b.item.deleted_length` is non-zero when `node_id` is None.

```json
{
  "CrdtGroupItem": {
    "deletedLength": 1,
    "id": "1:16",
    "left": "0:0",
    "parentId": "0:11",
    "right": "0:0"
  },
  "minVersion": 1,
  "version": 1
}
```

compared to the following when `deletedLength == 0`

```json
{
    "CrdtGroupItem": {
        "deletedLength": 0,
        "id": "0:13",
        "left": "0:0",
        "parentId": "0:1",
        "right": "0:0",
        "value": {
            "nodeId": "0:11"
        }
    },
    "minVersion": 1,
    "version": 1
}
```


It fixes the parsing of my file mentioned in #32 (19 `CrdtGroupItem` where `nodeId == None` and `deletedLength > 0`).

@Azeirah could you test if it fixes it for you too?