### PR TITLE
feat: add paper_size in SceneInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To convert rm files to other formats, you can use [rmc](https://github.com/rickl
 
 ### Unreleased
 
+New feature:
+
+- Add support for `paper_size` field on some SceneInfo
+
 ### v0.6.1
 
 Fixes:

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -143,21 +143,26 @@ class SceneInfo(Block):
     current_layer: LwwValue[CrdtId]
     background_visible: LwwValue[bool]
     root_document_visible: LwwValue[bool]
+    paper_size: tp.Optional[tuple[int, int]]
 
     @classmethod
     def from_stream(cls, stream: TaggedBlockReader) -> SceneInfo:
         current_layer = stream.read_lww_id(1)
         background_visible = stream.read_lww_bool(2)
         root_document_visible = stream.read_lww_bool(3)
+        paper_size = stream.read_int_pair(5) if stream.bytes_remaining_in_block() > 0 else None
 
         return SceneInfo(current_layer=current_layer,
                          background_visible=background_visible,
-                         root_document_visible=root_document_visible)
+                         root_document_visible=root_document_visible,
+                         paper_size=paper_size)
 
     def to_stream(self, writer: TaggedBlockWriter):
         writer.write_lww_id(1, self.current_layer)
         writer.write_lww_bool(2, self.background_visible)
         writer.write_lww_bool(3, self.root_document_visible)
+        if self.paper_size:
+            writer.write_int_pair(5, self.paper_size)
 
 
 @dataclass

--- a/src/rmscene/tagged_block_reader.py
+++ b/src/rmscene/tagged_block_reader.py
@@ -347,3 +347,10 @@ class TaggedBlockReader:
                 fmt = None
 
             return string, fmt
+
+    def read_int_pair(self, index: int) -> tp.Optional[tuple[int, int]]:
+        """Read a sub block containing two uint32"""
+        with self.read_subblock(index):
+            first = self.data.read_uint32()
+            second = self.data.read_uint32()
+            return first, second

--- a/src/rmscene/tagged_block_writer.py
+++ b/src/rmscene/tagged_block_writer.py
@@ -186,3 +186,9 @@ class TaggedBlockWriter:
             self.data.write_bool(is_ascii)
             self.data.write_bytes(b)
             self.write_int(2, fmt)
+
+    def write_int_pair(self, index: int, value: tuple[int, int]):
+        """Read a sub block containing two uint32"""
+        with self.write_subblock(index):
+            self.data.write_uint32(value[0])
+            self.data.write_uint32(value[1])

--- a/tests/test_scene_stream.py
+++ b/tests/test_scene_stream.py
@@ -280,11 +280,11 @@ def test_write_blocks():
 
 
 def test_blocks_keep_unknown_data_in_main_block():
-    # The "E1 FF" is represents new, unknown data -- note that this might need
+    # The "E1 FF" represents new, unknown data -- note that this might need
     # to be changed in future if the next id starts to actually be used in a
     # future update!
     data_hex = """
-    21000000 0000010D
+    2E000000 0000010D
     1C 06000000
        1F 0000
        2F 0000
@@ -292,6 +292,8 @@ def test_blocks_keep_unknown_data_in_main_block():
        1F 0000 21 01
     3C 05000000
        1F 0000 21 01
+    5C 08000000
+       7C050000 50070000
     E1 FF
     """
     buf = BytesIO(HEADER_V6 + bytes.fromhex(data_hex))


### PR DESCRIPTION
As discussed in https://github.com/ricklupton/rmscene/issues/39, https://github.com/ricklupton/rmscene/pull/34#issuecomment-2482306478 and https://github.com/ricklupton/rmscene/pull/34#issuecomment-2486829797 there is a new property in `SceneInfo` called `paperSize` according to the debug output of remarkable software

I changed the `test_blocks_keep_unknown_data_in_main_block` as suggested by the comment. As it is in hex and a bit hard to read, here is an explanation of the modification made :
| hex | signification |modifications|
|---|---|---|
|`2E000000 0000010D` | block definition | `21` to `2E` as the size of the `SceneInfo` is now 46 and not 33 |
|```1C 06000000   1F 0000   2F 0000``` | current_layer property | None |
|`2C 05000000   1F 0000 21 01` | background_visible property | None |
|`3C 05000000 1F 0000 21 01` | root_document_visible property  | None |
|`5C 08000000  7C050000 50070000` | (new) paper_size property | Added as suggested by the comment |
|`E1 FF` | new, unknown data  |  None |

I used the excess bytes `92, 8, 0, 0, 0, 124, 5, 0, 0, 80, 7, 0, 0` of https://github.com/ricklupton/rmscene/pull/34#issuecomment-2486829797

Closes #39