### PR TITLE
fix: background_visible, root_document_visible can be None in SceneInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To convert rm files to other formats, you can use [rmc](https://github.com/rickl
 
 ### Unreleased
 
+Fix:
+
+- Fix SceneInfo optional values ([#40](https://github.com/ricklupton/rmscene/issues/40))
+
 ### v0.6.1
 
 Fixes:

--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -141,14 +141,14 @@ class SceneInfo(Block):
         return (0, 1)
 
     current_layer: LwwValue[CrdtId]
-    background_visible: LwwValue[bool]
-    root_document_visible: LwwValue[bool]
+    background_visible: tp.Optional[LwwValue[bool]]
+    root_document_visible: tp.Optional[LwwValue[bool]]
 
     @classmethod
     def from_stream(cls, stream: TaggedBlockReader) -> SceneInfo:
         current_layer = stream.read_lww_id(1)
-        background_visible = stream.read_lww_bool(2)
-        root_document_visible = stream.read_lww_bool(3)
+        background_visible = stream.read_lww_bool(2) if stream.bytes_remaining_in_block() > 0 else None
+        root_document_visible = stream.read_lww_bool(3) if stream.bytes_remaining_in_block() > 0 else None
 
         return SceneInfo(current_layer=current_layer,
                          background_visible=background_visible,
@@ -156,8 +156,10 @@ class SceneInfo(Block):
 
     def to_stream(self, writer: TaggedBlockWriter):
         writer.write_lww_id(1, self.current_layer)
-        writer.write_lww_bool(2, self.background_visible)
-        writer.write_lww_bool(3, self.root_document_visible)
+        if self.background_visible:
+            writer.write_lww_bool(2, self.background_visible)
+        if self.root_document_visible:
+            writer.write_lww_bool(3, self.root_document_visible)
 
 
 @dataclass


### PR DESCRIPTION
See #40 for relevant info. If the use of `Optional` is okay, here is a MR that would fix #40.



_Also, I can rebase this on master after #41 is closed if you prefer_
