### PR TITLE
Add support for reMarkable firmware 3.27 SceneInfo fields

### DIFF
--- a/src/rmscene/scene_stream.py
+++ b/src/rmscene/scene_stream.py
@@ -144,6 +144,11 @@ class SceneInfo(Block):
     background_visible: tp.Optional[LwwValue[bool]]
     root_document_visible: tp.Optional[LwwValue[bool]]
     paper_size: tp.Optional[tuple[int, int]]
+    # New fields added in firmware 3.27
+    viewport: tp.Optional[LwwValue[tuple[float, float, float, float]]] = None
+    paper_size_raw: tp.Optional[tuple[float, float]] = None
+    paper_size_lww: tp.Optional[LwwValue[tuple[float, float]]] = None
+    unknown_bool_9: tp.Optional[LwwValue[bool]] = None
 
     @classmethod
     def from_stream(cls, stream: TaggedBlockReader) -> SceneInfo:
@@ -152,10 +157,28 @@ class SceneInfo(Block):
         root_document_visible = stream.read_lww_bool(3) if stream.bytes_remaining_in_block() > 0 else None
         paper_size = stream.read_int_pair(5) if stream.bytes_remaining_in_block() > 0 else None
 
+        # New fields from firmware 3.27
+        viewport = None
+        paper_size_raw = None
+        paper_size_lww = None
+        unknown_bool_9 = None
+        if stream.bytes_remaining_in_block() > 0 and stream.has_subblock(6):
+            viewport = stream.read_lww_double_rect(6)
+        if stream.bytes_remaining_in_block() > 0 and stream.has_subblock(7):
+            paper_size_raw = stream.read_double_pair(7)
+        if stream.bytes_remaining_in_block() > 0 and stream.has_subblock(8):
+            paper_size_lww = stream.read_lww_double_pair(8)
+        if stream.bytes_remaining_in_block() > 0 and stream.has_subblock(9):
+            unknown_bool_9 = stream.read_lww_subblock_bool(9)
+
         return SceneInfo(current_layer=current_layer,
                          background_visible=background_visible,
                          root_document_visible=root_document_visible,
-                         paper_size=paper_size)
+                         paper_size=paper_size,
+                         viewport=viewport,
+                         paper_size_raw=paper_size_raw,
+                         paper_size_lww=paper_size_lww,
+                         unknown_bool_9=unknown_bool_9)
 
     def to_stream(self, writer: TaggedBlockWriter):
         writer.write_lww_id(1, self.current_layer)
@@ -165,6 +188,14 @@ class SceneInfo(Block):
             writer.write_lww_bool(3, self.root_document_visible)
         if self.paper_size:
             writer.write_int_pair(5, self.paper_size)
+        if self.viewport is not None:
+            writer.write_lww_double_rect(6, self.viewport)
+        if self.paper_size_raw is not None:
+            writer.write_double_pair(7, self.paper_size_raw)
+        if self.paper_size_lww is not None:
+            writer.write_lww_double_pair(8, self.paper_size_lww)
+        if self.unknown_bool_9 is not None:
+            writer.write_lww_subblock_bool(9, self.unknown_bool_9)
 
 
 @dataclass

--- a/src/rmscene/tagged_block_reader.py
+++ b/src/rmscene/tagged_block_reader.py
@@ -368,3 +368,38 @@ class TaggedBlockReader:
             first = self.data.read_uint32()
             second = self.data.read_uint32()
             return first, second
+
+    def read_double_pair(self, index: int) -> tuple[float, float]:
+        """Read a sub block containing two float64."""
+        with self.read_subblock(index):
+            first = self.data.read_float64()
+            second = self.data.read_float64()
+            return first, second
+
+    def read_lww_double_pair(self, index: int) -> LwwValue[tuple[float, float]]:
+        """Read a LWW pair of doubles."""
+        with self.read_subblock(index):
+            timestamp = self.read_id(1)
+            with self.read_subblock(2):
+                first = self.data.read_float64()
+                second = self.data.read_float64()
+        return LwwValue(timestamp, (first, second))
+
+    def read_lww_double_rect(self, index: int) -> LwwValue[tuple[float, float, float, float]]:
+        """Read a LWW rect of four doubles."""
+        with self.read_subblock(index):
+            timestamp = self.read_id(1)
+            with self.read_subblock(2):
+                x = self.data.read_float64()
+                y = self.data.read_float64()
+                w = self.data.read_float64()
+                h = self.data.read_float64()
+        return LwwValue(timestamp, (x, y, w, h))
+
+    def read_lww_subblock_bool(self, index: int) -> LwwValue[bool]:
+        """Read a LWW bool where the value is wrapped in a subblock."""
+        with self.read_subblock(index):
+            timestamp = self.read_id(1)
+            with self.read_subblock(2):
+                value = self.data.read_bool()
+        return LwwValue(timestamp, value)

--- a/src/rmscene/tagged_block_writer.py
+++ b/src/rmscene/tagged_block_writer.py
@@ -193,7 +193,38 @@ class TaggedBlockWriter:
             self.write_int(2, fmt)
 
     def write_int_pair(self, index: int, value: tuple[int, int]):
-        """Read a sub block containing two uint32"""
+        """Write a sub block containing two uint32."""
         with self.write_subblock(index):
             self.data.write_uint32(value[0])
             self.data.write_uint32(value[1])
+
+    def write_double_pair(self, index: int, value: tuple[float, float]):
+        """Write a sub block containing two float64."""
+        with self.write_subblock(index):
+            self.data.write_float64(value[0])
+            self.data.write_float64(value[1])
+
+    def write_lww_double_pair(self, index: int, value: LwwValue[tuple[float, float]]):
+        """Write a LWW pair of doubles."""
+        with self.write_subblock(index):
+            self.write_id(1, value.timestamp)
+            with self.write_subblock(2):
+                self.data.write_float64(value.value[0])
+                self.data.write_float64(value.value[1])
+
+    def write_lww_double_rect(self, index: int, value: LwwValue[tuple[float, float, float, float]]):
+        """Write a LWW rect of four doubles."""
+        with self.write_subblock(index):
+            self.write_id(1, value.timestamp)
+            with self.write_subblock(2):
+                self.data.write_float64(value.value[0])
+                self.data.write_float64(value.value[1])
+                self.data.write_float64(value.value[2])
+                self.data.write_float64(value.value[3])
+
+    def write_lww_subblock_bool(self, index: int, value: LwwValue[bool]):
+        """Write a LWW bool where the value is wrapped in a subblock."""
+        with self.write_subblock(index):
+            self.write_id(1, value.timestamp)
+            with self.write_subblock(2):
+                self.data.write_bool(value.value)


### PR DESCRIPTION
I am using rmscene in a new project and realized that with firmware 3.27 several fields were added. 
Reverse engeneered the rm files from my own remarkable and added them. 

- Add viewport (LWW double rect) field for scroll/viewport tracking
- Add paper_size_raw (double pair) for raw paper dimensions
- Add paper_size_lww (LWW double pair) for LWW-based paper size
- Add unknown_bool_9 field (LWW bool with subblock wrapping)

Firmware 3.27 introduces these fields in SceneInfo block (type 0x0D, tags 6-9). Fully backwards-compatible: new fields are optional, old files still parse correctly.

Tests: 150/150 unit tests, 76/76 roundtrip tests with real .rm files passed.